### PR TITLE
Feature/calcuttj g4rw nu kaon

### DIFF
--- a/ubsim/EventWeight/Calculators/Geant4WeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/Geant4WeightCalc.cxx
@@ -120,7 +120,9 @@ void Geant4WeightCalc::Configure(fhicl::ParameterSet const& p,
 
   // Configure G4Reweighter
   bool totalonly = false;
-  if (fPdg==2212) totalonly = true;
+  std::vector<int> total_pdgs = {2212, 2112, -321, 321};
+  // if (fPdg==2212) totalonly = true;
+  if (std::find(total_pdgs.begin(), total_pdgs.end(), fPdg) != total_pdgs.end()) totalonly = true;
   ParMaker = new G4ReweightParameterMaker( FitParSets, totalonly );
   theReweighter = RWFactory.BuildReweighter(fPdg, &XSecFile, &FracsFile, ParMaker->GetFSHists(), ParMaker->GetElasticHist() );
 
@@ -290,6 +292,8 @@ Geant4WeightCalc::GetWeight(art::Event& e) {
       double mass = 0.;
       if( TMath::Abs(p_PDG) == 211 ) mass = 139.57;
       else if( p_PDG == 2212 ) mass = 938.28;
+      else if( p_PDG == 2112 ) mass = 939.565;
+      else if ( TMath::Abs(p_PDG) == 321 ) mass = 493.677;
 
       // We only want to record weights for one type of particle (defined by fPDG from the fcl file), so skip other particles
       if (p_PDG == fPdg){

--- a/ubsim/EventWeight/jobs/eventweight_microboone.fcl
+++ b/ubsim/EventWeight/jobs/eventweight_microboone.fcl
@@ -87,7 +87,7 @@ microboone_eventweight_justreint: {
 #just the reinteraction weight function
 microboone_eventweight_justreint.weight_functions: [ 
   reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
-  reinteractions_kplus, reinteractions_kminus, reinteractions_neutron
+  reinteractions_kplus, reinteractions_kminus #, reinteractions_neutron
 ]
 
 END_PROLOG

--- a/ubsim/EventWeight/jobs/eventweight_microboone.fcl
+++ b/ubsim/EventWeight/jobs/eventweight_microboone.fcl
@@ -85,6 +85,9 @@ microboone_eventweight_justreint: {
 }
 
 #just the reinteraction weight function
-microboone_eventweight_justreint.weight_functions: [ reinteractions_piplus, reinteractions_piminus, reinteractions_proton ]
+microboone_eventweight_justreint.weight_functions: [ 
+  reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
+  reinteractions_kplus, reinteractions_kminus, reinteractions_neutron
+]
 
 END_PROLOG

--- a/ubsim/EventWeight/jobs/eventweight_microboone.fcl
+++ b/ubsim/EventWeight/jobs/eventweight_microboone.fcl
@@ -87,7 +87,7 @@ microboone_eventweight_justreint: {
 #just the reinteraction weight function
 microboone_eventweight_justreint.weight_functions: [ 
   reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
-  reinteractions_kplus, reinteractions_kminus #, reinteractions_neutron
+  reinteractions_kplus, reinteractions_kminus, reinteractions_neutron
 ]
 
 END_PROLOG

--- a/ubsim/EventWeight/jobs/reint/eventweight_microboone_g4rwt_reint.fcl
+++ b/ubsim/EventWeight/jobs/reint/eventweight_microboone_g4rwt_reint.fcl
@@ -21,9 +21,11 @@ BEGIN_PROLOG
 
 microboone_eventweight_reint: {
   weight_functions_reint: [ 
-    reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
-    reinteractions_kplus, reinteractions_kminus
+    #reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
+    #reinteractions_kplus, reinteractions_kminus, reinteractions_neutron
+    reinteractions_neutron
   ]
+  
   reinteractions_piplus: {
     type: Geant4
     random_seed: 58
@@ -86,18 +88,18 @@ microboone_eventweight_reint: {
     pdg_to_reweight: -321
     debug: false
   }
-  #reinteractions_neutron: {
-  #  type: Geant4
-  #  random_seed: 63
-  #  parameters: @local::NeutronParameters
-  #  mode: multisim
-  #  number_of_multisims: 1000
-  #  fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" #"/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_fracs_neutron.root"
-  #  xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/neutron_cross_section.root" # "/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_cross_section_neutron.root"
-  #  makeoutputtree: false
-  #  pdg_to_reweight: 2112
-  #  debug: false
-  #}
+  reinteractions_neutron: {
+    type: Geant4
+    random_seed: 63
+    parameters: @local::NeutronParameters
+    mode: multisim
+    number_of_multisims: 1000
+    fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" #"/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_fracs_neutron.root"
+    xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/neutron_cross_section.root" # "/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_cross_section_neutron.root"
+    makeoutputtree: false
+    pdg_to_reweight: 2112
+    debug: false
+  }
 }
 
 ###

--- a/ubsim/EventWeight/jobs/reint/eventweight_microboone_g4rwt_reint.fcl
+++ b/ubsim/EventWeight/jobs/reint/eventweight_microboone_g4rwt_reint.fcl
@@ -22,7 +22,7 @@ BEGIN_PROLOG
 microboone_eventweight_reint: {
   weight_functions_reint: [ 
     reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
-    reinteractions_kplus, reinteractions_kminus, reinteractions_neutron
+    reinteractions_kplus, reinteractions_kminus
   ]
   reinteractions_piplus: {
     type: Geant4
@@ -86,18 +86,18 @@ microboone_eventweight_reint: {
     pdg_to_reweight: -321
     debug: false
   }
-  reinteractions_neutron: {
-    type: Geant4
-    random_seed: 63
-    parameters: @local::NeutronParameters
-    mode: multisim
-    number_of_multisims: 1000
-    fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" #"/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_fracs_neutron.root"
-    xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/neutron_cross_section.root" # "/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_cross_section_neutron.root"
-    makeoutputtree: false
-    pdg_to_reweight: 2112
-    debug: false
-  }
+  #reinteractions_neutron: {
+  #  type: Geant4
+  #  random_seed: 63
+  #  parameters: @local::NeutronParameters
+  #  mode: multisim
+  #  number_of_multisims: 1000
+  #  fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" #"/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_fracs_neutron.root"
+  #  xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/neutron_cross_section.root" # "/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_cross_section_neutron.root"
+  #  makeoutputtree: false
+  #  pdg_to_reweight: 2112
+  #  debug: false
+  #}
 }
 
 ###

--- a/ubsim/EventWeight/jobs/reint/eventweight_microboone_g4rwt_reint.fcl
+++ b/ubsim/EventWeight/jobs/reint/eventweight_microboone_g4rwt_reint.fcl
@@ -13,11 +13,17 @@
 #include "microboone_piplus_reweight_parameters.fcl"
 #include "microboone_piminus_reweight_parameters.fcl"
 #include "microboone_proton_reweight_parameters.fcl"
+#include "microboone_kplus_reweight_parameters.fcl"
+#include "microboone_kminus_reweight_parameters.fcl"
+#include "microboone_neutron_reweight_parameters.fcl"
 
 BEGIN_PROLOG
 
 microboone_eventweight_reint: {
-  weight_functions_reint: [ reinteractions_piplus, reinteractions_piminus, reinteractions_proton ]
+  weight_functions_reint: [ 
+    reinteractions_piplus, reinteractions_piminus, reinteractions_proton,
+    reinteractions_kplus, reinteractions_kminus, reinteractions_neutron
+  ]
   reinteractions_piplus: {
     type: Geant4
     random_seed: 58
@@ -42,6 +48,7 @@ microboone_eventweight_reint: {
     pdg_to_reweight: -211
     debug: false
   }
+
   reinteractions_proton: {
     type: Geant4
     random_seed: 60
@@ -52,6 +59,43 @@ microboone_eventweight_reint: {
     xsecfile: "$UBOONEDATA_DIR/systematics/reint/g4_cross_section_proton.root" # "/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_cross_section_proton.root"
     makeoutputtree: false
     pdg_to_reweight: 2212
+    debug: false
+  }
+
+  reinteractions_kplus: {
+    type: Geant4
+    random_seed: 61
+    parameters: @local::KPlusParameters
+    mode: multisim
+    number_of_multisims: 1000
+    fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" # "/uboone/app/users/kduffy/CC1k/MCC9/GeantReweight/g4_fracs_kplus.root"
+    xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/kplus_cross_section.root" # "/uboone/app/users/kduffy/CC1k/MCC9/GeantReweight/g4_cross_section_kplus.root"
+    makeoutputtree: false
+    pdg_to_reweight: 321
+    debug: false
+  }
+  reinteractions_kminus: {
+    type: Geant4
+    random_seed: 62
+    parameters: @local::KMinusParameters
+    mode: multisim
+    number_of_multisims: 1000
+    fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" # "/uboone/app/users/kduffy/CC1k/MCC9/GeantReweight/g4_fracs_kminus.root"
+    xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/kminus_cross_section.root" # "/uboone/app/users/kduffy/CC1k/MCC9/GeantReweight/g4_cross_section_kminus.root"
+    makeoutputtree: false
+    pdg_to_reweight: -321
+    debug: false
+  }
+  reinteractions_neutron: {
+    type: Geant4
+    random_seed: 63
+    parameters: @local::NeutronParameters
+    mode: multisim
+    number_of_multisims: 1000
+    fracsfile: "$UBOONEDATA_DIR/systematics/reint/g4_fracs_proton.root" #"/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_fracs_neutron.root"
+    xsecfile: "/exp/uboone/app/users/calcuttj/ubsim-work-mcc9/srcs/geant4reweight/geant4reweight/app/PredictionBase/neutron_cross_section.root" # "/uboone/app/users/kduffy/CC1pi/MCC9/GeantReweight/g4_cross_section_neutron.root"
+    makeoutputtree: false
+    pdg_to_reweight: 2112
     debug: false
   }
 }

--- a/ubsim/EventWeight/jobs/reint/microboone_kminus_reweight_parameters.fcl
+++ b/ubsim/EventWeight/jobs/reint/microboone_kminus_reweight_parameters.fcl
@@ -1,0 +1,21 @@
+BEGIN_PROLOG
+
+KMinusParameters: [
+  {
+    Name:       "fKMinusReac"
+    Cut:        "reac"
+    Range:      [10., 2005.]
+    Nominal:    1
+    Sigma:      0.2
+  },
+
+  {
+    Name:       "fKMinusElast"
+    Cut:        "elast"
+    Range:      [10.0, 2005.00]
+    Nominal:    1.0
+    Sigma:      0.2
+  }
+]
+
+END_PROLOG 

--- a/ubsim/EventWeight/jobs/reint/microboone_kplus_reweight_parameters.fcl
+++ b/ubsim/EventWeight/jobs/reint/microboone_kplus_reweight_parameters.fcl
@@ -1,0 +1,21 @@
+BEGIN_PROLOG
+
+KPlusParameters: [
+  {
+    Name:       "fKPlusReac"
+    Cut:        "reac"
+    Range:      [10., 2005.]
+    Nominal:    1
+    Sigma:      0.2
+  },
+
+  {
+    Name:       "fKPlusElast"
+    Cut:        "elast"
+    Range:      [10.0, 2005.00]
+    Nominal:    1.0
+    Sigma:      0.2
+  }
+]
+
+END_PROLOG 

--- a/ubsim/EventWeight/jobs/reint/microboone_neutron_reweight_parameters.fcl
+++ b/ubsim/EventWeight/jobs/reint/microboone_neutron_reweight_parameters.fcl
@@ -1,0 +1,21 @@
+BEGIN_PROLOG
+
+NeutronParameters: [
+  {
+    Name:       "fNeutronReac"
+    Cut:        "reac"
+    Range:      [10., 2005.]
+    Nominal:    1
+    Sigma:      0.2
+  },
+
+  {
+    Name:       "fNeutronElast"
+    Cut:        "elast"
+    Range:      [75.0, 2005.00]
+    Nominal:    1.0
+    Sigma:      0.2
+  }
+]
+
+END_PROLOG 

--- a/ubsim/EventWeight/jobs/reint/microboone_neutron_reweight_parameters.fcl
+++ b/ubsim/EventWeight/jobs/reint/microboone_neutron_reweight_parameters.fcl
@@ -4,7 +4,7 @@ NeutronParameters: [
   {
     Name:       "fNeutronReac"
     Cut:        "reac"
-    Range:      [10., 2005.]
+    Range:      [55., 2005.]
     Nominal:    1
     Sigma:      0.2
   },
@@ -12,7 +12,7 @@ NeutronParameters: [
   {
     Name:       "fNeutronElast"
     Cut:        "elast"
-    Range:      [75.0, 2005.00]
+    Range:      [30.0, 2005.00]
     Nominal:    1.0
     Sigma:      0.2
   }

--- a/ubsim/EventWeight/jobs/reint/microboone_neutron_reweight_parameters.fcl
+++ b/ubsim/EventWeight/jobs/reint/microboone_neutron_reweight_parameters.fcl
@@ -12,7 +12,7 @@ NeutronParameters: [
   {
     Name:       "fNeutronElast"
     Cut:        "elast"
-    Range:      [30.0, 2005.00]
+    Range:      [100.0, 2005.00]
     Nominal:    1.0
     Sigma:      0.2
   }

--- a/ubsim/EventWeight/jobs/run_eventweight_microboone_g4rwt_reint.fcl
+++ b/ubsim/EventWeight/jobs/run_eventweight_microboone_g4rwt_reint.fcl
@@ -45,7 +45,6 @@ outputs: {
 }
 physics.producers.eventweightreint.reinteractions_kminus.debug: false
 physics.producers.eventweightreint.reinteractions_kplus.debug: false
-physics.producers.eventweightreint.reinteractions_neutron.debug: false
 physics.producers.eventweightreint.reinteractions_piminus.debug: false
 physics.producers.eventweightreint.reinteractions_piplus.debug: false
 physics.producers.eventweightreint.reinteractions_proton.debug: false

--- a/ubsim/EventWeight/jobs/run_eventweight_microboone_g4rwt_reint.fcl
+++ b/ubsim/EventWeight/jobs/run_eventweight_microboone_g4rwt_reint.fcl
@@ -43,3 +43,9 @@ outputs: {
    compressionLevel: 1
  }
 }
+physics.producers.eventweightreint.reinteractions_kminus.debug: false
+physics.producers.eventweightreint.reinteractions_kplus.debug: false
+physics.producers.eventweightreint.reinteractions_neutron.debug: false
+physics.producers.eventweightreint.reinteractions_piminus.debug: false
+physics.producers.eventweightreint.reinteractions_piplus.debug: false
+physics.producers.eventweightreint.reinteractions_proton.debug: false


### PR DESCRIPTION
Includes backported Reweighting for kaons and neutrons -- though there are issues with the neutrons. As such I've only included kaons in the event weight setup 

Needs a new version of G4RW -- will update once that is ready