### PR TITLE
Adding multi_sigma reweighting mode for spline systematics

### DIFF
--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronFeynmanScalingWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronFeynmanScalingWeightCalc.cxx
@@ -133,15 +133,21 @@ namespace evwgh {
       fWeightArray.resize(2*fNmultisims);
       
       for (unsigned int i=0;i<fWeightArray.size();i++) {
-	fWeightArray[i].resize(FSKPlusFitCov->GetNcols());      
-	if (fMode.find("multisim") != std::string::npos ){
-	  for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-            fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-	  }
-	}
-	else{
-	  std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
-	}
+        fWeightArray[i].resize(FSKPlusFitCov->GetNcols());      
+        if (fMode.find("multisim") != std::string::npos ){
+          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+                  fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+          }
+        }
+        else if (fMode.find("multi_sigma") != std::string::npos ){
+          // NOT IMPLEMENTED YET
+          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+            fWeightArray[i][j] = 1.;
+          }
+        }
+        else{
+          std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
+        }
       }
     }
   

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronFeynmanScalingWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronFeynmanScalingWeightCalc.cxx
@@ -198,7 +198,7 @@ namespace evwgh {
           
       //Let's make a weights based on the calculator you have requested 
       if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){       
-        for (unsigned int i = 0; int(weight[inu].size()) < fNmultisims; i++) {
+        for (unsigned int i = 0; int(weight[inu].size()) < fNmultisims && i < fWeightArray.size(); i++) {
           if(fWeightCalc.find("MicroBooNE") != std::string::npos){
             
             //
@@ -223,7 +223,11 @@ namespace evwgh {
               weight[inu].push_back(test_weight.second);
             }
           }
-        }//Iterate through the number of universes      
+        }//Iterate through the number of universes
+        // If we didn't get enough weights (calculator returned false too often), pad with a sentinel value, -9898.
+        while(int(weight[inu].size()) < fNmultisims) {
+          weight[inu].push_back(-9898.0);
+        }
       } // make sure we are multisiming
 
         

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronNormalizationWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronNormalizationWeightCalc.cxx
@@ -84,12 +84,16 @@ namespace evwgh {
       fWeightArray.resize(2*fNmultisims);
            
       for (double& weight : fWeightArray) {
-	if (fMode.find("multisim") != std::string::npos ){
-          weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-	}	
-	else{
+        if (fMode.find("multisim") != std::string::npos ){
+                weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+        }	
+        else if (fMode.find("multi_sigma") != std::string::npos ){
+          // NOT IMPLEMENTED YET
           weight = 1.;
-	}
+        }
+        else{
+          weight = 1.;
+        }
       }
     }//Use LArSoft Randoms
 

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronNormalizationWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronNormalizationWeightCalc.cxx
@@ -49,6 +49,7 @@ namespace evwgh {
 
     std::string fGenieModuleLabel{};
     int fNmultisims{};
+    std::vector<double> fmultisigmas{};
     int fprimaryHad{};
     std::string fWeightCalc{};
     std::vector< double > fWeightArray{};
@@ -72,6 +73,12 @@ namespace evwgh {
     fWeightCalc                 =   pset.get<std::string>("weight_calculator");
     fMode                       =   pset.get<std::string>("mode");
     fUseMBRands                 =   pset.get<bool>("use_MiniBooNE_random_numbers");
+
+    // Only require multisigmas when running in multisigma mode.
+    if ( fMode.find("multisigma") != std::string::npos ) {
+      std::cout << "Multi-sigma mode enabled for PrimaryHadronNormalizationWeightCalc" << std::endl;
+      fmultisigmas = pset.get<std::vector<double> >("multisigmas");
+    }
     
     //
     // This is the meat of this, select random numbers that will be the 
@@ -82,18 +89,19 @@ namespace evwgh {
     }//Use MiniBooNE Randoms
     else{
       fWeightArray.resize(2*fNmultisims);
-           
+      
+      int weight_index = 0;
       for (double& weight : fWeightArray) {
         if (fMode.find("multisim") != std::string::npos ){
                 weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
         }	
-        else if (fMode.find("multi_sigma") != std::string::npos ){
-          // NOT IMPLEMENTED YET
-          weight = 1.;
+        else if (fMode.find("multisigma") != std::string::npos ){
+          weight = fmultisigmas[weight_index];
         }
         else{
           weight = 1.;
         }
+        weight_index++;
       }
     }//Use LArSoft Randoms
 
@@ -135,33 +143,33 @@ namespace evwgh {
       
   
       //Let's make a weights based on the calculator you have requested 
-      if(fMode.find("multisim") != std::string::npos){       
-	for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims; i++) {
-	  if(fWeightCalc.find("MicroBooNE") != std::string::npos){
-	    
-	    //
-	    //This way we only have to call the WeightCalc once
-	    // 
-	    std::pair<bool, double> test_weight =
-	      MicroBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
-	    
-	    if(test_weight.first){
-	      weight[inu].push_back(test_weight.second);
-	    }
-	  }
-	  if(fWeightCalc.find("MiniBooNE") != std::string::npos){
+      if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){       
+        for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims; i++) {
+          if(fWeightCalc.find("MicroBooNE") != std::string::npos){
+            
+            //
+            //This way we only have to call the WeightCalc once
+            // 
+            std::pair<bool, double> test_weight =
+              MicroBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
+            
+            if(test_weight.first){
+              weight[inu].push_back(test_weight.second);
+            }
+          }
+          if(fWeightCalc.find("MiniBooNE") != std::string::npos){
 
-	    //
-	    //This way we only have to call the WeightCalc once
-	    // 
-	    std::pair<bool, double> test_weight =
-	      MiniBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
-	    
-	    if(test_weight.first){
-	      weight[inu].push_back(test_weight.second);
-	    }
-	  }
-	}//Iterate through the number of universes      
+            //
+            //This way we only have to call the WeightCalc once
+            // 
+            std::pair<bool, double> test_weight =
+              MiniBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
+            
+            if(test_weight.first){
+              weight[inu].push_back(test_weight.second);
+            }
+          }
+        }//Iterate through the number of universes      
       } // make sure we are multisiming
 
         

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSWCentralSplineVariationWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSWCentralSplineVariationWeightCalc.cxx
@@ -192,15 +192,21 @@ namespace evwgh {
       fWeightArray.resize(2*fNmultisims);
       
       for (unsigned int i=0;i<fWeightArray.size();i++) {
-	fWeightArray[i].resize(HARPCov->GetNcols());
-	if (fMode.find("multisim") != std::string::npos ){
-	  for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-            fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-	  }//Iterate over the covariance matrix size
-	}
-	else{
-	  std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
-	}
+        fWeightArray[i].resize(HARPCov->GetNcols());
+        if (fMode.find("multisim") != std::string::npos ){
+          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+                  fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+          }//Iterate over the covariance matrix size
+        }
+        else if (fMode.find("multi_sigma") != std::string::npos ){
+          // NOT IMPLEMENTED YET
+          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+            fWeightArray[i][j] = 1.;
+          }
+        }
+        else{
+          std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
+        }
       }//iterate over the number of universes 
     }
 

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSWCentralSplineVariationWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSWCentralSplineVariationWeightCalc.cxx
@@ -192,21 +192,15 @@ namespace evwgh {
       fWeightArray.resize(2*fNmultisims);
       
       for (unsigned int i=0;i<fWeightArray.size();i++) {
-        fWeightArray[i].resize(HARPCov->GetNcols());
-        if (fMode.find("multisim") != std::string::npos ){
-          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-                  fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-          }//Iterate over the covariance matrix size
-        }
-        else if (fMode.find("multi_sigma") != std::string::npos ){
-          // NOT IMPLEMENTED YET
-          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-            fWeightArray[i][j] = 1.;
-          }
-        }
-        else{
-          std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
-        }
+	fWeightArray[i].resize(HARPCov->GetNcols());
+	if (fMode.find("multisim") != std::string::npos ){
+	  for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+            fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+	  }//Iterate over the covariance matrix size
+	}
+	else{
+	  std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
+	}
       }//iterate over the number of universes 
     }
 

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
@@ -77,7 +77,6 @@ namespace evwgh {
     auto const parameter_list = pset.get<std::vector<std::string> >("parameter_list");
     auto const dataInput      = pset.get< std::string >("ExternalData");
     fNmultisims			=   pset.get<int>("number_of_multisims");
-    fmultisigmas = pset.get<std::vector<double> >("multisigmas");
     fprimaryHad			=   pset.get< std::vector< int > >("PrimaryHadronGeantCode");
     fWeightCalc                 =   pset.get<std::string>("weight_calculator");
     fMode                       =   pset.get<std::string>("mode");

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
@@ -126,15 +126,21 @@ namespace evwgh {
       fWeightArray.resize(2*fNmultisims);
       
       for (unsigned int i=0;i<fWeightArray.size();i++) {
-	fWeightArray[i].resize(SWK0FitCov->GetNcols());      
-	if (fMode.find("multisim") != std::string::npos ){
-	  for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-            fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-	  }
-	}
-	else{
-	  std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
-	}
+        fWeightArray[i].resize(SWK0FitCov->GetNcols());      
+        if (fMode.find("multisim") != std::string::npos ){
+          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+                  fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+          }
+        }
+        else if (fMode.find("multi_sigma") != std::string::npos ){
+          // NOT IMPLEMENTED YET
+          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
+            fWeightArray[i][j] = 1.;
+          }
+        }
+        else{
+          std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
+        }
       }//Iterate through random number array
     }//Use LArSoft Randoms 
  

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
@@ -196,7 +196,7 @@ namespace evwgh {
           
       //Let's make a weights based on the calculator you have requested 
       if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){       
-        for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims; i++) {
+        for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims && i < fWeightArray.size(); i++) {
           if(fWeightCalc.find("MicroBooNE") != std::string::npos){
             
             //
@@ -221,7 +221,11 @@ namespace evwgh {
               weight[inu].push_back(test_weight.second);
             }
           }
-        }//Iterate through the number of universes      
+        }//Iterate through the number of universes
+        // If we didn't get enough weights (calculator returned false too often), pad with a sentinel value, -9898.
+        while(int(weight[inu].size()) < fNmultisims) {
+          weight[inu].push_back(-9898.0);
+        }
       } // make sure we are multisiming
 
 

--- a/ubsim/EventWeight/Calculators/FluxHistWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/FluxHistWeightCalc.cxx
@@ -77,7 +77,7 @@ namespace evwgh {
 
     if (fMode.find("multisim") != std::string::npos )
       for (double& weight : fWeightArray) weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-    else if (fMode.find("multi_sigma") != std::string::npos )
+    else if (fMode.find("multisigma") != std::string::npos )
       // NOT IMPLEMENTED YET
       for (double& weight : fWeightArray) weight = 1.;
     else

--- a/ubsim/EventWeight/Calculators/FluxHistWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/FluxHistWeightCalc.cxx
@@ -77,6 +77,9 @@ namespace evwgh {
 
     if (fMode.find("multisim") != std::string::npos )
       for (double& weight : fWeightArray) weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+    else if (fMode.find("multi_sigma") != std::string::npos )
+      // NOT IMPLEMENTED YET
+      for (double& weight : fWeightArray) weight = 1.;
     else
       for (double& weight : fWeightArray) weight = 1.;
   }

--- a/ubsim/EventWeight/Calculators/FluxHistWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/FluxHistWeightCalc.cxx
@@ -77,9 +77,6 @@ namespace evwgh {
 
     if (fMode.find("multisim") != std::string::npos )
       for (double& weight : fWeightArray) weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-    else if (fMode.find("multisigma") != std::string::npos )
-      // NOT IMPLEMENTED YET
-      for (double& weight : fWeightArray) weight = 1.;
     else
       for (double& weight : fWeightArray) weight = 1.;
   }

--- a/ubsim/EventWeight/Calculators/FluxUnisimWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/FluxUnisimWeightCalc.cxx
@@ -151,12 +151,17 @@ namespace evwgh {
       if (fMode.find("multisim") != std::string::npos ) {
         for (double& weight : fWeightArray) weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
       }
-      else if (fMode.find("multi_sigma") != std::string::npos ) {
+      else if (fMode.find("multisigma") != std::string::npos ) {
         // multi sigma mode uses three universes: -1sigma, 0sigma, +1sigma
         // corresponding to the three input files: CentralValue_hist_file, PositiveSystematicVariation_hist_file, NegativeSystematicVariation_hist_file
-        fWeightArray[0] = -1;
-        fWeightArray[1] = 0;
-        fWeightArray[2] = 1;
+        int weight_index = 0;
+        for (double& weight : fWeightArray) {
+          if (weight_index == 0) weight = -1.;
+          else if (weight_index == 1) weight = 0.;
+          else if (weight_index == 2) weight = 1.;
+          else throw cet::exception(__FUNCTION__) << GetName()<<"::More than 3 universes for multisigma mode in FluxUnisimWeightCalc!" << std::endl;
+          weight_index++;
+        }
       }
       else {
         for (double& weight : fWeightArray) weight=1.;
@@ -224,7 +229,7 @@ namespace evwgh {
       double enu=mclist[inu].GetNeutrino().Nu().E();      
 
       //Let's make a weights based on the calculator you have requested 
-      if(fMode.find("multisim") != std::string::npos){
+      if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){
         for (int i=0;i<fNuni;i++) {
 
           if(fWeightCalc.find("MicroBooNE") != std::string::npos){

--- a/ubsim/EventWeight/Calculators/FluxUnisimWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/FluxUnisimWeightCalc.cxx
@@ -154,14 +154,7 @@ namespace evwgh {
       else if (fMode.find("multisigma") != std::string::npos ) {
         // multi sigma mode uses three universes: -1sigma, 0sigma, +1sigma
         // corresponding to the three input files: CentralValue_hist_file, PositiveSystematicVariation_hist_file, NegativeSystematicVariation_hist_file
-        int weight_index = 0;
-        for (double& weight : fWeightArray) {
-          if (weight_index == 0) weight = -1.;
-          else if (weight_index == 1) weight = 0.;
-          else if (weight_index == 2) weight = 1.;
-          else throw cet::exception(__FUNCTION__) << GetName()<<"::More than 3 universes for multisigma mode in FluxUnisimWeightCalc!" << std::endl;
-          weight_index++;
-        }
+        fWeightArray = {-1., 0., 1.};
       }
       else {
         for (double& weight : fWeightArray) weight=1.;

--- a/ubsim/EventWeight/Calculators/FluxUnisimWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/FluxUnisimWeightCalc.cxx
@@ -119,13 +119,13 @@ namespace evwgh {
 
     for (int iptyp=0;iptyp<4;iptyp++) {
       for (int intyp=0;intyp<4;intyp++) {
-	for (int ibin=0;ibin<200;ibin++) { //Grab events from ibin+1 
+        for (int ibin=0;ibin<200;ibin++) { //Grab events from ibin+1 
 
-	  fCV[iptyp][intyp][ibin]=(dynamic_cast<TH1F*> (fcv.Get(Form("h5%d%d",ptype[iptyp],ntype[intyp]))))->GetBinContent(ibin+1);
-	  fRWpos[iptyp][intyp][ibin]=(dynamic_cast<TH1F*> (frwpos.Get(Form("h5%d%d",ptype[iptyp],ntype[intyp]))))->GetBinContent(ibin+1);
-	  fRWneg[iptyp][intyp][ibin]=(dynamic_cast<TH1F*> (frwneg.Get(Form("h5%d%d",ptype[iptyp],ntype[intyp]))))->GetBinContent(ibin+1);
+          fCV[iptyp][intyp][ibin]=(dynamic_cast<TH1F*> (fcv.Get(Form("h5%d%d",ptype[iptyp],ntype[intyp]))))->GetBinContent(ibin+1);
+          fRWpos[iptyp][intyp][ibin]=(dynamic_cast<TH1F*> (frwpos.Get(Form("h5%d%d",ptype[iptyp],ntype[intyp]))))->GetBinContent(ibin+1);
+          fRWneg[iptyp][intyp][ibin]=(dynamic_cast<TH1F*> (frwneg.Get(Form("h5%d%d",ptype[iptyp],ntype[intyp]))))->GetBinContent(ibin+1);
 
-	}// energy bin
+        }// energy bin
       }//   type of neutrinos
     }//     type of hadron parent 
     
@@ -148,10 +148,19 @@ namespace evwgh {
       fWeightArray.resize(fNuni);
       
       // This sets up if we want to reweight events or just assess 1sigma shifts 
-      if (fMode.find("multisim") != std::string::npos )
+      if (fMode.find("multisim") != std::string::npos ) {
         for (double& weight : fWeightArray) weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-      else
+      }
+      else if (fMode.find("multi_sigma") != std::string::npos ) {
+        // multi sigma mode uses three universes: -1sigma, 0sigma, +1sigma
+        // corresponding to the three input files: CentralValue_hist_file, PositiveSystematicVariation_hist_file, NegativeSystematicVariation_hist_file
+        fWeightArray[0] = -1;
+        fWeightArray[1] = 0;
+        fWeightArray[2] = 1;
+      }
+      else {
         for (double& weight : fWeightArray) weight=1.;
+      }
     }//Use LArSoft Randoms
 
   }
@@ -198,7 +207,7 @@ namespace evwgh {
       else if ( fluxlist[inu].fptype==130                               ) ptype = 2;
       else if ( fluxlist[inu].fptype==321 || fluxlist[inu].fptype==-321 ) ptype = 3;                                    
       else {
-	throw cet::exception(__FUNCTION__) << GetName()<<"::Unknown ptype "<<fluxlist[0].fptype<< std::endl;
+        throw cet::exception(__FUNCTION__) << GetName()<<"::Unknown ptype "<<fluxlist[0].fptype<< std::endl;
       }
 
       // Discover the neutrino type
@@ -208,7 +217,7 @@ namespace evwgh {
       else if ( fluxlist[inu].fntype== 14  ) ntype=2;
       else if ( fluxlist[inu].fntype==-14  ) ntype=3;
       else {
-	throw cet::exception(__FUNCTION__) << GetName()<<"::Unknown ntype "<<fluxlist[0].fntype<< std::endl;
+       throw cet::exception(__FUNCTION__) << GetName()<<"::Unknown ntype "<<fluxlist[0].fntype<< std::endl;
       }
 
       // Collect neutrino energy
@@ -216,16 +225,16 @@ namespace evwgh {
 
       //Let's make a weights based on the calculator you have requested 
       if(fMode.find("multisim") != std::string::npos){
-	for (int i=0;i<fNuni;i++) {
+        for (int i=0;i<fNuni;i++) {
 
-	  if(fWeightCalc.find("MicroBooNE") != std::string::npos){
-	    weight[inu][i]=MicroBooNEWeightCalc(enu, ptype, ntype, i, PosOnly);
-	  }
-	  if(fWeightCalc.find("MiniBooNE") != std::string::npos){
-	    weight[inu][i]=MiniBooNEWeightCalc(enu, ptype, ntype, i, PosOnly);
-	  }
+          if(fWeightCalc.find("MicroBooNE") != std::string::npos){
+            weight[inu][i]=MicroBooNEWeightCalc(enu, ptype, ntype, i, PosOnly);
+          }
+          if(fWeightCalc.find("MiniBooNE") != std::string::npos){
+            weight[inu][i]=MiniBooNEWeightCalc(enu, ptype, ntype, i, PosOnly);
+          }
 
-	}//Iterate through the number of universes      
+        }//Iterate through the number of universes      
       }
     }
      

--- a/ubsim/EventWeight/Calculators/SCCWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/SCCWeightCalc.cxx
@@ -94,18 +94,23 @@ namespace evwgh {
         fWeightArray[i] = fGaussRandom->fire(0, 1.0);
        }
     }
+    else if (fMode.find("multisigma") != std::string::npos) {
+      for (int i=0; i<fNmultisims; i++) {
+        fWeightArray[i] = parsigmas[i];
+      }
+    }
     else {
       for (int i=0; i<fNmultisims; i++) {
         fWeightArray[i] = 1.0;
       }
     }
 
-    if (pars.size() != parsigmas.size())
+    if ((pars.size() != parsigmas.size()) && (fMode.find("multisigma") == std::string::npos))
        throw cet::exception(__FUNCTION__)
          << GetName()
          << ": Bad fcl configuration. "
          << "parameter_list and parameter_sigma need to have same "
-         << "number of parameters."
+         << "number of parameters, unless multisigma mode is specified."
          << std::endl;
 
     for (auto& s : pars) {

--- a/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
@@ -389,7 +389,7 @@ namespace evwgh {
       genie::rew::GSyst_t current_knob = knobs_to_use.at( k );
 
       for ( size_t u = 0u; u < num_universes; ++u ) {
-	if ( mode.find("multisim") != std::string::npos ) {
+	      if ( mode.find("multisim") != std::string::npos ) {
           reweightingSigmas[k][u] = par_sigmas[k] * CLHEP::RandGaussQ::shoot(&engine, 0., 1.);
         }
         else if ( mode.find("pm1sigma") != std::string::npos ) {
@@ -400,6 +400,10 @@ namespace evwgh {
         }
         else if ( mode.find("central_value") != std::string::npos ) {
           reweightingSigmas[k][u] = 0.; // we'll correct for a modified CV below if needed
+        }
+        else if ( mode.find("multi_sigma") != std::string::npos ) {
+          // NOT IMPLEMENTED YET
+          reweightingSigmas[k][u] = 0.;
         }
 	else {
 	  reweightingSigmas[k][u] = par_sigmas[k];

--- a/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
@@ -319,10 +319,10 @@ namespace evwgh {
 
     auto const mode = pset.get<std::string>( "mode" );
 
-    if ( pars.size() != par_sigmas.size() ) {
+    if ( (pars.size() != par_sigmas.size()) && (mode.find("multi_sigma") == std::string::npos) ) {
       throw cet::exception(__PRETTY_FUNCTION__) << GetName()
         << "::Bad fcl configuration. parameter_list and parameter_sigma"
-        << " need to have same number of parameters.";
+        << " need to have same number of parameters, unless multi_sigma mode is specified.";
     }
 
     if ( !pars.empty() && !fQuietMode ) MF_LOG_INFO("GENIEWeightCalc") << "Configuring"

--- a/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
@@ -402,11 +402,10 @@ namespace evwgh {
           reweightingSigmas[k][u] = 0.; // we'll correct for a modified CV below if needed
         }
         else if ( mode.find("multisigma") != std::string::npos ) {
-          // NOT IMPLEMENTED YET
-          reweightingSigmas[k][u] = 0.;
+          reweightingSigmas[k][u] = par_sigmas[u];
         }
-	else {
-	  reweightingSigmas[k][u] = par_sigmas[k];
+        else {
+          reweightingSigmas[k][u] = par_sigmas[k];
         }
 
         if ( !fQuietMode ) MF_LOG_INFO("GENIEWeightCalc")

--- a/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/UBGenieWeightCalc.cxx
@@ -319,10 +319,10 @@ namespace evwgh {
 
     auto const mode = pset.get<std::string>( "mode" );
 
-    if ( (pars.size() != par_sigmas.size()) && (mode.find("multi_sigma") == std::string::npos) ) {
+    if ( (pars.size() != par_sigmas.size()) && (mode.find("multisigma") == std::string::npos) ) {
       throw cet::exception(__PRETTY_FUNCTION__) << GetName()
         << "::Bad fcl configuration. parameter_list and parameter_sigma"
-        << " need to have same number of parameters, unless multi_sigma mode is specified.";
+        << " need to have same number of parameters, unless multisigma mode is specified.";
     }
 
     if ( !pars.empty() && !fQuietMode ) MF_LOG_INFO("GENIEWeightCalc") << "Configuring"
@@ -401,7 +401,7 @@ namespace evwgh {
         else if ( mode.find("central_value") != std::string::npos ) {
           reweightingSigmas[k][u] = 0.; // we'll correct for a modified CV below if needed
         }
-        else if ( mode.find("multi_sigma") != std::string::npos ) {
+        else if ( mode.find("multisigma") != std::string::npos ) {
           // NOT IMPLEMENTED YET
           reweightingSigmas[k][u] = 0.;
         }


### PR DESCRIPTION
Adds the `multisigma` reweighting option for GENIE and BNB flux uncertainties, for example getting event weights for the [-3, -2, -1, 0, 1, 2, 3] sigma variations of a specific knob, to be used when generating spline systematics (as a potential alternative to covariance matrix systematics).

This adds the same functionality as in [SBNcode](https://github.com/SBNSoftware/sbncode/blob/110b14392d667f89474fd1bb20335ad5db20bd63/sbncode/SBNEventWeight/Calculators/CrossSections/GenieWeightCalc.cxx#L378), with an example [SBNcode fhicl](https://github.com/SBNSoftware/sbncode/blob/110b14392d667f89474fd1bb20335ad5db20bd63/sbncode/SBNEventWeight/jobs/genie/eventweight_genie_sbn.fcl#L93).

Does not work for PrimaryHadronSWCentralSplineVariationWeightCalc systematics, which sample from a HARP 78x78 covariance matrix.

This also fixes an issue in PrimaryHadronFeynmanScalingWeightCalc.cxx and PrimaryHadronSanfordWangWeightCalc.cxx which can cause out-of-bounds fWeightArray indexing (causing bad_alloc when running locally, and causing a segmentation error and job failure on the grid). MicroBooNEWeightCalc can internally fluctuate with non-positive values and therefore fail to add a weight, and when this happens often enough, fWeightArray would run out of elements and then start being accessed out of bounds.

Developed alongside [ubana PR 80](https://github.com/uboone/ubana/pull/80).

Does not add Geant4 re-interaction uncertainty spline weights, since the necessary inputs for this were not saved in the same part of the SURPRISE files.

I briefly investigated adding splines for NuMI flux with PPFX, but it seems like it would require large PPFX changes. The NuMI horn current and beamline geometry uncertainties could be treated as splines more easily.
