### PR TITLE
Update refactored geant configuration to use standard geometry

### DIFF
--- a/ubsim/Simulation/simulationservices_microboone.fcl
+++ b/ubsim/Simulation/simulationservices_microboone.fcl
@@ -16,7 +16,7 @@ microboone_larvoxelcalculator: @local::standard_larvoxelcalculator
 microboone_larg4detector:
 {
   category: "world"
-  gdmlFileName_ : "microboonev12_nowires.gdml"
+  gdmlFileName_ : "microboonev12.gdml"
 }
 
 microboone_physicslist:


### PR DESCRIPTION
Use gdml file microboonev12;gdml instead of microboonev12_nowires.gdml in refactored geant LArG4Detector service configuration.  This is because of discrepancies between the two gdml files and to be compatible with art Geometry service.