### PR TITLE
Kaon flux spline weight fix

### DIFF
--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronFeynmanScalingWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronFeynmanScalingWeightCalc.cxx
@@ -53,7 +53,6 @@ namespace evwgh {
     std::string fGenieModuleLabel{};
     std::vector<std::string> fParameter_list{};
     float fParameter_sigma{};
-    std::vector<double> fmultisigmas{};
     int fNmultisims{};
     int fprimaryHad{};
     std::string fWeightCalc{};
@@ -90,10 +89,16 @@ namespace evwgh {
     fSeed 			=   pset.get<double>("random_seed");
     fUseMBRands                 =   pset.get<bool>("use_MiniBooNE_random_numbers");
 
-    // Only require multisigmas when running in multisigma mode.
+    // This calculator smears a multi-parameter fit through its covariance
+    // matrix, so its uncertainty is not one-dimensional: a single-sigma scan
+    // would shift all parameters coherently along an arbitrary (parameter-
+    // ordering-dependent) direction whose length is sqrt(Nparams) sigma, not
+    // 1 sigma.  Use multisim mode and build a covariance from the universes.
     if ( fMode.find("multisigma") != std::string::npos ) {
-      std::cout << "Multi-sigma mode enabled for PrimaryHadronFeynmanScalingWeightCalc" << std::endl;
-      fmultisigmas = pset.get<std::vector<double> >("multisigmas");
+      throw art::Exception(art::errors::Configuration)
+        << GetName() << ": multisigma mode is not supported for "
+        << "PrimaryHadronFeynmanScaling because the uncertainty is a "
+        << "multi-parameter covariance; use multisim mode instead.";
     }
 
     // Getting External Data:
@@ -146,11 +151,6 @@ namespace evwgh {
                   fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
           }
         }
-        else if (fMode.find("multisigma") != std::string::npos ){
-          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-            fWeightArray[i][j] = fmultisigmas[j];
-          }
-        }
         else{
           std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
         }
@@ -197,7 +197,7 @@ namespace evwgh {
       }// Hadronic parent check
           
       //Let's make a weights based on the calculator you have requested 
-      if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){       
+      if (fMode.find("multisim") != std::string::npos){
         for (unsigned int i = 0; int(weight[inu].size()) < fNmultisims && i < fWeightArray.size(); i++) {
           if(fWeightCalc.find("MicroBooNE") != std::string::npos){
             

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronNormalizationWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronNormalizationWeightCalc.cxx
@@ -78,6 +78,11 @@ namespace evwgh {
     if ( fMode.find("multisigma") != std::string::npos ) {
       std::cout << "Multi-sigma mode enabled for PrimaryHadronNormalizationWeightCalc" << std::endl;
       fmultisigmas = pset.get<std::vector<double> >("multisigmas");
+      if (fmultisigmas.size() != static_cast<size_t>(fNmultisims)) {
+        throw art::Exception(art::errors::Configuration)
+          << GetName() << ": multisigmas size (" << fmultisigmas.size()
+          << ") does not match number_of_multisims (" << fNmultisims << ")";
+      }
     }
     
     //
@@ -88,20 +93,27 @@ namespace evwgh {
       fWeightArray = PrimaryHadronNormalizationWeightCalc::MiniBooNERandomNumbers(parameter_list.at(0));
     }//Use MiniBooNE Randoms
     else{
-      fWeightArray.resize(2*fNmultisims);
-      
-      int weight_index = 0;
-      for (double& weight : fWeightArray) {
-        if (fMode.find("multisim") != std::string::npos ){
-                weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
-        }	
-        else if (fMode.find("multisigma") != std::string::npos ){
-          weight = fmultisigmas[weight_index];
+      if (fMode.find("multisigma") != std::string::npos ){
+        // Multisigma mode: the sigma grid itself is the "random number" array,
+        // exactly one entry per universe.  (Previously this branch resized to
+        // 2*fNmultisims -- the spare-draw sizing only multisim needs -- and
+        // read fmultisigmas[weight_index] past the end of the sigma list,
+        // filling universes 7..13 with out-of-bounds heap garbage.)
+        fWeightArray = fmultisigmas;
+      }
+      else{
+        // multisim mode draws 2*fNmultisims Gaussians: the second half are
+        // spare draws consumed by the truncated-Gaussian rejection loop in
+        // GetWeight when a draw gives an unphysical (w <= 0) weight.
+        fWeightArray.resize(2*fNmultisims);
+        for (double& weight : fWeightArray) {
+          if (fMode.find("multisim") != std::string::npos ){
+            weight = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
+          }
+          else{
+            weight = 1.;
+          }
         }
-        else{
-          weight = 1.;
-        }
-        weight_index++;
       }
     }//Use LArSoft Randoms
 
@@ -136,23 +148,42 @@ namespace evwgh {
       // 
       
       if (fluxlist[inu].ftptype != fprimaryHad){	
-	weight[inu].resize(fNmultisims);
-	std::fill(weight[inu].begin(), weight[inu].end(), 1);
-	continue; //now move on to the next neutrino
+        weight[inu].resize(fNmultisims);
+        std::fill(weight[inu].begin(), weight[inu].end(), 1);
+        continue; //now move on to the next neutrino
       }// Hadronic parent check
       
   
-      //Let's make a weights based on the calculator you have requested 
-      if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){       
-        for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims; i++) {
+      //Let's make a weights based on the calculator you have requested
+      if (fMode.find("multisigma") != std::string::npos){
+        // Multisigma mode: exactly one weight per sigma point, in the order of
+        // the `multisigmas` fcl parameter.  A weight w = 1 + sigma <= 0 (a
+        // downward normalization shift of 100% or more) is unphysical and is
+        // stored as 0 ("no K- production in this universe") rather than being
+        // skipped: skipping shifted later sigma points into earlier slots and
+        // walked into uninitialized entries of fWeightArray, destroying the
+        // slot<->sigma correspondence.
+        for (int i = 0; i < fNmultisims; i++) {
+          std::pair<bool, double> test_weight(false, 0.);
+          if (fWeightCalc.find("MicroBooNE") != std::string::npos){
+            test_weight = MicroBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
+          }
+          else if (fWeightCalc.find("MiniBooNE") != std::string::npos){
+            test_weight = MiniBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
+          }
+          weight[inu].push_back(test_weight.first ? test_weight.second : 0.);
+        }
+      }
+      else if (fMode.find("multisim") != std::string::npos){
+        for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims && i < fWeightArray.size(); i++) {
           if(fWeightCalc.find("MicroBooNE") != std::string::npos){
-            
+
             //
             //This way we only have to call the WeightCalc once
-            // 
+            //
             std::pair<bool, double> test_weight =
               MicroBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
-            
+
             if(test_weight.first){
               weight[inu].push_back(test_weight.second);
             }
@@ -161,15 +192,21 @@ namespace evwgh {
 
             //
             //This way we only have to call the WeightCalc once
-            // 
+            //
             std::pair<bool, double> test_weight =
               MiniBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
-            
+
             if(test_weight.first){
               weight[inu].push_back(test_weight.second);
             }
           }
-        }//Iterate through the number of universes      
+        }//Iterate through the number of universes
+        // If we ran out of spare draws (calculator returned false too often),
+        // pad with the sentinel value -9898 (matches the sibling PrimaryHadron
+        // calculators) instead of reading past the end of fWeightArray.
+        while(int(weight[inu].size()) < fNmultisims) {
+          weight[inu].push_back(-9898.0);
+        }
       } // make sure we are multisiming
 
         

--- a/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
+++ b/ubsim/EventWeight/Calculators/BNBPrimaryHadron/PrimaryHadronSanfordWangWeightCalc.cxx
@@ -50,7 +50,6 @@ namespace evwgh {
 
     std::string fGenieModuleLabel{};
     int fNmultisims{};
-    std::vector<double> fmultisigmas{};
     std::vector<int> fprimaryHad{};
     std::string fWeightCalc{};
     std::string ExternalDataInput{};
@@ -84,10 +83,16 @@ namespace evwgh {
     fSeed                       =   pset.get<double>("random_seed");
     fUseMBRands                 =   pset.get<bool>("use_MiniBooNE_random_numbers");
 
-    // Only require multisigmas when running in multisigma mode.
+    // This calculator smears a multi-parameter fit through its covariance
+    // matrix, so its uncertainty is not one-dimensional: a single-sigma scan
+    // would shift all parameters coherently along an arbitrary (parameter-
+    // ordering-dependent) direction whose length is sqrt(Nparams) sigma, not
+    // 1 sigma.  Use multisim mode and build a covariance from the universes.
     if ( fMode.find("multisigma") != std::string::npos ) {
-      std::cout << "Multi-sigma mode enabled for PrimaryHadronSanfordWangWeightCalc" << std::endl;
-      fmultisigmas = pset.get<std::vector<double> >("multisigmas");
+      throw art::Exception(art::errors::Configuration)
+        << GetName() << ": multisigma mode is not supported for "
+        << "PrimaryHadronSanfordWang because the uncertainty is a "
+        << "multi-parameter covariance; use multisim mode instead.";
     }
 
     // Getting External Data:
@@ -140,11 +145,6 @@ namespace evwgh {
                   fWeightArray[i][j] = CLHEP::RandGaussQ::shoot(&engine, 0, 1.);
           }
         }
-        else if (fMode.find("multisigma") != std::string::npos ){
-          for(unsigned int j = 0; j < fWeightArray[i].size(); j++){
-            fWeightArray[i][j] = fmultisigmas[j];
-          }
-        }
         else{
           std::fill(fWeightArray[i].begin(), fWeightArray[i].end(), 1.);
         }
@@ -193,18 +193,18 @@ namespace evwgh {
         std::fill(weight[inu].begin(), weight[inu].end(), 1);
         continue; //now move on to the next neutrino
       }// Hadronic parent check
-          
-      //Let's make a weights based on the calculator you have requested 
-      if((fMode.find("multisim") != std::string::npos) || (fMode.find("multisigma") != std::string::npos)){       
+
+      //Let's make a weights based on the calculator you have requested
+      if (fMode.find("multisim") != std::string::npos){
         for (unsigned int i = 0;  int(weight[inu].size()) < fNmultisims && i < fWeightArray.size(); i++) {
           if(fWeightCalc.find("MicroBooNE") != std::string::npos){
-            
+
             //
             //This way we only have to call the WeightCalc once
-            // 
+            //
             std::pair<bool, double> test_weight =
               MicroBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
-            
+
             if(test_weight.first){
               weight[inu].push_back(test_weight.second);
             }
@@ -213,10 +213,10 @@ namespace evwgh {
 
             //
             //This way we only have to call the WeightCalc once
-            // 
+            //
             std::pair<bool, double> test_weight =
               MiniBooNEWeightCalc(fluxlist[inu], fWeightArray[i]);
-            
+
             if(test_weight.first){
               weight[inu].push_back(test_weight.second);
             }


### PR DESCRIPTION
Fixed Kaon flux normalization multisigma, removed multisigma from FeynmanScaling and SanfordWang code that uses covariance matrix sampling.

Fixes issues in the earlier PR https://github.com/uboone/ubsim/pull/11.

Companion to https://github.com/uboone/ubana/pull/89.